### PR TITLE
Working past PHP Fatal error:  Cannot use $this as lexical variable on line 46

### DIFF
--- a/classes/restful/header.php
+++ b/classes/restful/header.php
@@ -40,13 +40,13 @@ class Restful_Header extends Kohana_Http_Header {
 		$result = array();
 
 		// Sort values by quality
-		$this->sort_values_by_quality();
+		$header = $this;
 
 		// Match against accept criteria
-		array_walk($accept, function ($type, $values) use ( & $result, $this)
+		array_walk($accept, function ($type, $values) use ( & $result, $header)
 			{
 				if ($values AND $this->offsetExists($type)
-				            AND ($accept_header = $this[$type]))
+				            AND ($accept_header = $header[$type]))
 				{
 					if ($match = Valid::match_accept_headers($values, $accept_header))
 					{


### PR DESCRIPTION
Hi - I'm not sure if this is a pull you'll want to implement but the only way I could work around this issue in PHP 5.3. I think it's fixed in 5.4.
